### PR TITLE
Remove Invalid ServerState error codes for CUC api

### DIFF
--- a/errorCodesCommercialCustomer.md
+++ b/errorCodesCommercialCustomer.md
@@ -2,14 +2,10 @@
 
 | Short&nbsp;error&nbsp;code | Name | Description |
 | -------- | -------- | -------- |
-| E-CUC-0001 | InvalidUserServerState | Invalid user server state. |
-| E-CUC-0002 | InvalidUserAddressServerState | Invalid user address server state. |
-| E-CUC-0003 | InvalidAccountServerState | Invalid account server state. |
 | E-CUC-0004 | UsernameNotAvailable | Username is not available. |
 | E-CUC-0005 | PasswordStrength | Password strength is not strong enough. |
-| E-CUC-0006 | InvalidStreetNumber | Ether a Lot Number or a Street Number is required. |
+| E-CUC-0006 | InvalidStreetNumber | Either a Lot Number or a Street Number is required. |
 | E-CUC-0008 | InvalidCountry | Country is not supported. |
-| E-CUC-0010 | InvalidRegistrationServerState | Invalid registration server state. |
 | E-CUC-0011 | EmailAlreadyRegistered | This email address is already registered in the system. |
 | E-CUC-0012 | InvalidCardNumber | Card number is invalid. |
 | E-CUC-0013 | InvalidAccountNumber | Account number is invalid. |


### PR DESCRIPTION
Invalid ServerState errors are the result of either a bug in the code or an attempt to hack. They are not the result of end user's input.
Beside that, there is already an invalidServerState Problem Type.

API-18624
API-18625
API-18626
API-18653
API-18514