### PR TITLE
API-30217: Consumer API - Include Consumer API link on index page.

### DIFF
--- a/errorCodes.xml
+++ b/errorCodes.xml
@@ -4,6 +4,7 @@
 <problem title="Basket API" href="./?codes=errorCodesBasket" />
 <problem title="Checkout API" href="./?codes=errorCodesCheckout" />
 <problem title="CommercialCustomer API" href="./?codes=errorCodesCommercialCustomer" />
+<problem title="Consumer API" href="./?codes=errorCodesConsumer" />
 <problem title="Input Schema Errors" href="./?codes=errorCodesInputSchemaErrors" />
 <problem title="Ordering API" href="./?codes=errorCodesOrdering" />
 <problem title="Payment API" href="./?codes=errorCodesPayment" />


### PR DESCRIPTION
Adds a link to the Consumer API page onto the Problem Details homepage. Was previously only accessible from the Validation Error details page.

**Link to related Jira ticket:** <https://bunnings.atlassian.net/browse/API-30217>

[API-30217]

[API-30217]: https://bunnings.atlassian.net/browse/API-30217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ