### PR TITLE
BUNDIG-64397: Document E-CHK-0098 MarketplaceCurrencyNotMatchingCountry

### DIFF
--- a/errorCodesCheckout.md
+++ b/errorCodesCheckout.md
@@ -102,6 +102,7 @@ This catalogue of error codes are generated from the Checkout Domain which is co
 | E-CHK-0095                 | MaxLineQuantityTimesLength                    | This is additional validation when selected length or packet for timber or PktSplit product. Current maximum value: 9999.99                                        |
 | E-CHK-0096                 | ItemMissingSellingTaxCodeConfiguration        | An item in the basket has a purchasing tax code which is not mapped to a selling tax code in Checkout                                                              |
 | E-CHK-0097                 | OnePassIdWhenProvidedMustBeGuid               | OnePass identity when provided must be a GUID                                                                                                                      |
+| E-CHK-0098                 | MarketplaceCurrencyNotMatchingCountry         | Marketplace order currency does not match expected basket currency. Got '{0}', expected '{1}'                                                                      |
 
 ## Checkout Basket call
 

--- a/errorCodesCheckout.md
+++ b/errorCodesCheckout.md
@@ -102,7 +102,7 @@ This catalogue of error codes are generated from the Checkout Domain which is co
 | E-CHK-0095                 | MaxLineQuantityTimesLength                    | This is additional validation when selected length or packet for timber or PktSplit product. Current maximum value: 9999.99                                        |
 | E-CHK-0096                 | ItemMissingSellingTaxCodeConfiguration        | An item in the basket has a purchasing tax code which is not mapped to a selling tax code in Checkout                                                              |
 | E-CHK-0097                 | OnePassIdWhenProvidedMustBeGuid               | OnePass identity when provided must be a GUID                                                                                                                      |
-| E-CHK-0098                 | MarketplaceCurrencyNotMatchingCountry         | Marketplace order currency does not match expected basket currency. Got '{0}', expected '{1}'                                                                      |
+| E-CHK-0098                 | MarketplaceCurrencyNotMatchingCountry         | Marketplace order currency does not match expected basket currency.                                                                                                |
 
 ## Checkout Basket call
 


### PR DESCRIPTION
BUNDIG-64397 : Add E-CHK-0098 (`MarketplaceCurrencyNotMatchingCountry`) to `errorCodesCheckout.md`

